### PR TITLE
Upgrade dependencies and override mcp-sdk version to 0.18.1

### DIFF
--- a/infobip-openapi-mcp-core/pom.xml
+++ b/infobip-openapi-mcp-core/pom.xml
@@ -13,8 +13,8 @@
 
 	<properties>
         <jakarta-servlet.version>6.1.0</jakarta-servlet.version>
-		<swagger-parser.version>2.1.36</swagger-parser.version>
-        <nimbus-jwt.version>10.6</nimbus-jwt.version>
+		<swagger-parser.version>2.1.38</swagger-parser.version>
+        <nimbus-jwt.version>10.8</nimbus-jwt.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,14 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Dependencies: -->
-        <spring-ai.version>1.1.0</spring-ai.version>
-        <spring-boot.version>3.5.7</spring-boot.version>
+        <spring-ai.version>1.1.2</spring-ai.version>
+        <spring-boot.version>3.5.11</spring-boot.version>
+        <mcp-sdk.version>0.18.1</mcp-sdk.version>
         <jspecify.version>1.0.0</jspecify.version>
-        <junit.version>5.14.1</junit.version>
-        <mockito.version>5.20.0</mockito.version>
-        <assertj.version>3.27.6</assertj.version>
-        <wiremock.version>3.13.1</wiremock.version>
+        <junit.version>5.14.3</junit.version>
+        <mockito.version>5.21.0</mockito.version>
+        <assertj.version>3.27.7</assertj.version>
+        <wiremock.version>3.13.2</wiremock.version>
     </properties>
 
     <dependencyManagement>
@@ -73,6 +74,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.modelcontextprotocol.sdk</groupId>
+                <artifactId>mcp-bom</artifactId>
+                <version>${mcp-sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This PR brings in a critical fix from Java MCP SDK: [java-sdk/issues/#724](https://github.com/modelcontextprotocol/java-sdk/issues/724), which fixes compatibility with popular MCP clients such as VS Code and Cursor editors.

Unfortunately, the MCP SDK versions required for the fix (`0.18.0` and newer) are incompatible with current release versions of Spring AI, specifically its [mcp-annotations](https://github.com/spring-ai-community/mcp-annotations) library. The support for newer MCP SDK has landed on their main branch, but as of version `0.8.0` has not yet been released.

This PR will need to be updated with the release version of mcp-annotations when it becomes available.

In the meantime, a workaround mentioned [here](https://github.com/modelcontextprotocol/java-sdk/issues/724#issuecomment-3722301929) remains an option for server implementations.