### PR TITLE
Fix object-valued query parameters breaking URI expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Tool calls with a JSON object as a query parameter value (OpenAPI `form` style, `explode: true`) now send one query parameter per object property (e.g. `{"R":100,"G":200,"B":150}` becomes `R=100&G=200&B=150`) instead of failing with a URI expansion error.
+
 ## 0.1.16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Tool calls with a JSON object as a query parameter value (OpenAPI `form` style, `explode: true`) now send one query parameter per object property (e.g. `{"R":100,"G":200,"B":150}` becomes `R=100&G=200&B=150`) instead of failing with a URI expansion error.
+- Tool calls with a JSON object as a header parameter value (OpenAPI `simple` style, `explode: false`) now send comma-separated property/value pairs (e.g. `{"R":100,"G":200,"B":150}` becomes `R,100,G,200,B,150`) instead of an invalid header value.
 
 ## 0.1.16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tool calls with a JSON object as a query parameter value (OpenAPI `form` style, `explode: true`) now send one query parameter per object property (e.g. `{"R":100,"G":200,"B":150}` becomes `R=100&G=200&B=150`) instead of failing with a URI expansion error.
 - Tool calls with a JSON object as a header parameter value (OpenAPI `simple` style, `explode: false`) now send comma-separated property/value pairs (e.g. `{"R":100,"G":200,"B":150}` becomes `R,100,G,200,B,150`) instead of an invalid header value.
+- Tool calls with a JSON object as a cookie parameter value now send one cookie per object property, named after the property (e.g. `{"R":100,"G":200,"B":150}` becomes cookies `R=100`, `G=200`, `B=150`) instead of an invalid cookie value. The OpenAPI specification leaves object serialization undefined for `form` style cookies with `explode: true`; this mirrors query parameter handling for consistency.
 
 ## 0.1.16
 

--- a/README.md
+++ b/README.md
@@ -150,11 +150,14 @@ currently only supports the OpenAPI default: `form` style with `explode: true` f
 |-------------------------------|---------------------------------------|----------------------------------------|
 | `"blue"`                      | `color=blue`                          | `color: blue`                           |
 | `["blue","black","brown"]`    | `color=blue&color=black&color=brown`  | `color: blue,black,brown`               |
-| `{"R":100,"G":200,"B":150}`  | `R=100&G=200&B=150`                   | not supported                           |
+| `{"R":100,"G":200,"B":150}`  | `R=100&G=200&B=150`                   | `color: R,100,G,200,B,150`              |
 
-Note that an object value is exploded into one parameter per property, named after the property rather than `color`,
-matching the OpenAPI specification for `form` style with `explode: true`. Other styles and explode combinations are
-not currently supported.
+Note that a query object value is exploded into one parameter per property, named after the property rather than
+`color`, matching the OpenAPI specification for `form` style with `explode: true`. A header object value instead keeps
+the single `color` header name and lists each property name and value as comma-separated pairs, matching `simple`
+style with `explode: false`. Cookie parameters do not support object values: the specification leaves object
+serialization undefined for `form` style cookies with `explode: true`. Other styles and explode combinations are not
+currently supported.
 
 ### Tool NamingStrategy
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ built-in filter that removes regex pattern property from OpenAPI schemas set
 >
 > Both approaches can be combined.
 
+### Parameter handling
+
+OpenAPI allows parameters to be serialized in different [styles][19], with or without `explode`. The framework
+currently only supports the OpenAPI default: `form` style with `explode: true` for query and cookie parameters, and
+`simple` style with `explode: false` for header parameters. Given a parameter named `color`:
+
+| Value                        | Query (`form`, `explode: true`)      | Header (`simple`, `explode: false`) |
+|-------------------------------|---------------------------------------|----------------------------------------|
+| `"blue"`                      | `color=blue`                          | `color: blue`                           |
+| `["blue","black","brown"]`    | `color=blue&color=black&color=brown`  | `color: blue,black,brown`               |
+| `{"R":100,"G":200,"B":150}`  | `R=100&G=200&B=150`                   | not supported                           |
+
+Note that an object value is exploded into one parameter per property, named after the property rather than `color`,
+matching the OpenAPI specification for `form` style with `explode: true`. Other styles and explode combinations are
+not currently supported.
+
 ### Tool NamingStrategy
 
 MCP servers expose functionalities to AI agents as tools. Each tool is identified by a name which is accompanied by a
@@ -640,3 +656,5 @@ This project is licensed under the [MIT License](LICENSE).
 [17]: https://modelcontextprotocol.io/specification/2025-11-25/basic/prompts "Prompts in MCP specification"
 
 [18]: https://mustache.github.io "Mustache — Logic-less templates"
+
+[19]: https://swagger.io/docs/specification/v3_0/serialization/ "Parameter serialization in OpenAPI specification"

--- a/README.md
+++ b/README.md
@@ -146,18 +146,18 @@ OpenAPI allows parameters to be serialized in different [styles][19], with or wi
 currently only supports the OpenAPI default: `form` style with `explode: true` for query and cookie parameters, and
 `simple` style with `explode: false` for header parameters. Given a parameter named `color`:
 
-| Value                        | Query (`form`, `explode: true`)      | Header (`simple`, `explode: false`) |
-|-------------------------------|---------------------------------------|----------------------------------------|
-| `"blue"`                      | `color=blue`                          | `color: blue`                           |
-| `["blue","black","brown"]`    | `color=blue&color=black&color=brown`  | `color: blue,black,brown`               |
-| `{"R":100,"G":200,"B":150}`  | `R=100&G=200&B=150`                   | `color: R,100,G,200,B,150`              |
+| Value                        | Query (`form`, `explode: true`)      | Header (`simple`, `explode: false`) | Cookie (`form`, `explode: true`)      |
+|-------------------------------|---------------------------------------|----------------------------------------|---------------------------------------|
+| `"blue"`                      | `color=blue`                          | `color: blue`                           | `color=blue`                          |
+| `["blue","black","brown"]`    | `color=blue&color=black&color=brown`  | `color: blue,black,brown`               | `color=blue; color=black; color=brown`|
+| `{"R":100,"G":200,"B":150}`  | `R=100&G=200&B=150`                   | `color: R,100,G,200,B,150`              | `R=100; G=200; B=150`                 |
 
-Note that a query object value is exploded into one parameter per property, named after the property rather than
-`color`, matching the OpenAPI specification for `form` style with `explode: true`. A header object value instead keeps
-the single `color` header name and lists each property name and value as comma-separated pairs, matching `simple`
-style with `explode: false`. Cookie parameters do not support object values: the specification leaves object
-serialization undefined for `form` style cookies with `explode: true`. Other styles and explode combinations are not
-currently supported.
+Note that a query or cookie object value is exploded into one parameter per property, named after the property rather
+than `color`, matching the OpenAPI specification for `form` style with `explode: true`. A header object value instead
+keeps the single `color` header name and lists each property name and value as comma-separated pairs, matching
+`simple` style with `explode: false`. The specification leaves object serialization undefined for `form` style
+cookies with `explode: true`; the framework mirrors query parameter handling for consistency, but this is not a
+spec-mandated behavior. Other styles and explode combinations are not currently supported.
 
 ### Tool NamingStrategy
 

--- a/infobip-openapi-mcp-core/src/main/java/com/infobip/openapi/mcp/openapi/tool/ToolHandler.java
+++ b/infobip-openapi-mcp-core/src/main/java/com/infobip/openapi/mcp/openapi/tool/ToolHandler.java
@@ -411,9 +411,30 @@ public class ToolHandler {
     /**
      * Adds a header parameter to the request specification.
      * Currently only OpenAPI default "simple" style header parameters are supported with "explode" set to false.
-     * The values are comma-separated if multiple values are provided.
+     * Given a parameter named {@code color}:
+     * <ul>
+     *   <li>a string value {@code "blue"} is sent as {@code color: blue}</li>
+     *   <li>an array value {@code ["blue","black","brown"]} is sent as {@code color: blue,black,brown}</li>
+     *   <li>an object value {@code {"R":100,"G":200,"B":150}} is sent as {@code color: R,100,G,200,B,150}</li>
+     * </ul>
      */
     private void addHeaderParameter(RestClient.RequestHeadersSpec<?> spec, String name, Object value) {
+        if (value instanceof Map<?, ?> mapValue) {
+            var combinedValue = new StringBuilder();
+            mapValue.forEach((propertyName, propertyValue) -> {
+                if (propertyValue != null) {
+                    if (!combinedValue.isEmpty()) {
+                        combinedValue.append(",");
+                    }
+                    combinedValue.append(propertyName).append(",").append(propertyValue);
+                }
+            });
+            if (combinedValue.isEmpty()) {
+                return;
+            }
+            spec.header(name, combinedValue.toString());
+            return;
+        }
         if (value instanceof Iterable<?> iterableValue) {
             var combinedValue = new StringBuilder();
             for (var item : iterableValue) {

--- a/infobip-openapi-mcp-core/src/main/java/com/infobip/openapi/mcp/openapi/tool/ToolHandler.java
+++ b/infobip-openapi-mcp-core/src/main/java/com/infobip/openapi/mcp/openapi/tool/ToolHandler.java
@@ -9,6 +9,7 @@ import com.infobip.openapi.mcp.infrastructure.metrics.MetricService;
 import com.infobip.openapi.mcp.openapi.schema.DecomposedRequestData;
 import com.infobip.openapi.mcp.progress.ProgressUpdateProvider;
 import io.modelcontextprotocol.spec.McpSchema;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import org.jspecify.annotations.NullMarked;
@@ -380,9 +381,23 @@ public class ToolHandler {
     /**
      * Adds a query parameter to the URI builder.
      * Currently only OpenAPI default "form" style query parameters are supported with "explode" set to true.
+     * Given a parameter named {@code color}:
+     * <ul>
+     *   <li>a string value {@code "blue"} is sent as {@code color=blue}</li>
+     *   <li>an array value {@code ["blue","black","brown"]} is sent as
+     *   {@code color=blue&color=black&color=brown}</li>
+     *   <li>an object value {@code {"R":100,"G":200,"B":150}} is exploded into one query parameter per
+     *   property, named after the property rather than {@code color}: {@code R=100&G=200&B=150}</li>
+     * </ul>
      */
     private void addQueryParameter(UriBuilder uriBuilder, String name, Object value) {
-        if (value instanceof Iterable<?> iterableValue) {
+        if (value instanceof Map<?, ?> mapValue) {
+            mapValue.forEach((propertyName, propertyValue) -> {
+                if (propertyValue != null) {
+                    uriBuilder.queryParam(propertyName.toString(), propertyValue.toString());
+                }
+            });
+        } else if (value instanceof Iterable<?> iterableValue) {
             for (var item : iterableValue) {
                 if (item != null) {
                     uriBuilder.queryParam(name, item.toString());

--- a/infobip-openapi-mcp-core/src/main/java/com/infobip/openapi/mcp/openapi/tool/ToolHandler.java
+++ b/infobip-openapi-mcp-core/src/main/java/com/infobip/openapi/mcp/openapi/tool/ToolHandler.java
@@ -457,9 +457,25 @@ public class ToolHandler {
     /**
      * Adds a cookie parameter to the URI request specification.
      * Currently only OpenAPI default "form" style cookie parameters are supported with "explode" set to true.
+     * Given a parameter named {@code color}:
+     * <ul>
+     *   <li>a string value {@code "blue"} is sent as a single cookie {@code color=blue}</li>
+     *   <li>an array value {@code ["blue","black","brown"]} is sent as three cookies named
+     *   {@code color}</li>
+     *   <li>an object value {@code {"R":100,"G":200,"B":150}} is sent as one cookie per property,
+     *   named after the property rather than {@code color}, mirroring query parameter handling since
+     *   the OpenAPI specification leaves object serialization undefined for "form" style cookies with
+     *   "explode" set to true</li>
+     * </ul>
      */
     private void addCookieParameter(RestClient.RequestHeadersSpec<?> spec, String name, Object value) {
-        if (value instanceof Iterable<?> iterableValue) {
+        if (value instanceof Map<?, ?> mapValue) {
+            mapValue.forEach((propertyName, propertyValue) -> {
+                if (propertyValue != null) {
+                    spec.cookie(propertyName.toString(), propertyValue.toString());
+                }
+            });
+        } else if (value instanceof Iterable<?> iterableValue) {
             for (var item : iterableValue) {
                 if (item != null) {
                     spec.cookie(name, item.toString());

--- a/infobip-openapi-mcp-core/src/test/java/com/infobip/openapi/mcp/openapi/tool/ToolHandlerTest.java
+++ b/infobip-openapi-mcp-core/src/test/java/com/infobip/openapi/mcp/openapi/tool/ToolHandlerTest.java
@@ -371,6 +371,33 @@ class ToolHandlerTest {
         }
 
         @Test
+        void shouldHandleRequestWithObjectHeaderValueAsCommaSeparatedPairs() {
+            // Given
+            var fullOperation = new FullOperation("/users", PathItem.HttpMethod.GET, new Operation(), new OpenAPI());
+            var colorHeader = new LinkedHashMap<String, Object>();
+            colorHeader.put("R", 100);
+            colorHeader.put("G", 200);
+            colorHeader.put("B", 150);
+            var decomposedSchema = new DecomposedRequestData(
+                    new DecomposedRequestData.ParametersByType(
+                            Map.of(), Map.of(), Map.of("X-Color", colorHeader), Map.of()),
+                    null);
+            var responseBody = "Response with object header value";
+
+            wireMockServer.stubFor(get(urlPathEqualTo("/users"))
+                    .withHeader("X-Color", equalTo("R,100,G,200,B,150"))
+                    .withHeader("Accept", equalTo("application/json"))
+                    .willReturn(aResponse().withStatus(200).withBody(responseBody)));
+
+            // When
+            var result = toolHandler.handleToolCall(fullOperation, decomposedSchema, createTestContext());
+
+            // Then
+            then(extractTextContent(result.content())).isEqualTo(responseBody);
+            then(result.isError()).isFalse();
+        }
+
+        @Test
         void shouldHandleRequestWithCookies() {
             // Given
             var fullOperation = new FullOperation("/users", PathItem.HttpMethod.GET, new Operation(), new OpenAPI());

--- a/infobip-openapi-mcp-core/src/test/java/com/infobip/openapi/mcp/openapi/tool/ToolHandlerTest.java
+++ b/infobip-openapi-mcp-core/src/test/java/com/infobip/openapi/mcp/openapi/tool/ToolHandlerTest.java
@@ -446,6 +446,35 @@ class ToolHandlerTest {
         }
 
         @Test
+        void shouldHandleRequestWithObjectCookieValueExplodedAsSeparateCookies() {
+            // Given
+            var fullOperation = new FullOperation("/users", PathItem.HttpMethod.GET, new Operation(), new OpenAPI());
+            var colorCookie = new LinkedHashMap<String, Object>();
+            colorCookie.put("R", 100);
+            colorCookie.put("G", 200);
+            colorCookie.put("B", 150);
+            var decomposedSchema = new DecomposedRequestData(
+                    new DecomposedRequestData.ParametersByType(
+                            Map.of(), Map.of(), Map.of(), Map.of("color", colorCookie)),
+                    null);
+            var responseBody = "Response with object cookie value";
+
+            wireMockServer.stubFor(get(urlPathEqualTo("/users"))
+                    .withCookie("R", equalTo("100"))
+                    .withCookie("G", equalTo("200"))
+                    .withCookie("B", equalTo("150"))
+                    .withHeader("Accept", equalTo("application/json"))
+                    .willReturn(aResponse().withStatus(200).withBody(responseBody)));
+
+            // When
+            var result = toolHandler.handleToolCall(fullOperation, decomposedSchema, createTestContext());
+
+            // Then
+            then(extractTextContent(result.content())).isEqualTo(responseBody);
+            then(result.isError()).isFalse();
+        }
+
+        @Test
         void shouldHandleRequestWithAuthenticationHeader() {
             // Given
             var fullOperation = new FullOperation("/users", PathItem.HttpMethod.GET, new Operation(), new OpenAPI());

--- a/infobip-openapi-mcp-core/src/test/java/com/infobip/openapi/mcp/openapi/tool/ToolHandlerTest.java
+++ b/infobip-openapi-mcp-core/src/test/java/com/infobip/openapi/mcp/openapi/tool/ToolHandlerTest.java
@@ -32,6 +32,7 @@ import io.modelcontextprotocol.spec.McpSchema;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
@@ -158,6 +159,35 @@ class ToolHandlerTest {
             wireMockServer.stubFor(get(urlPathEqualTo("/users"))
                     .withQueryParam("role", equalTo("admin"))
                     .withQueryParam("role", equalTo("user"))
+                    .withHeader("Accept", equalTo("application/json"))
+                    .willReturn(aResponse().withStatus(200).withBody(responseBody)));
+
+            // When
+            var result = toolHandler.handleToolCall(fullOperation, decomposedSchema, createTestContext());
+
+            // Then
+            then(extractTextContent(result.content())).isEqualTo(responseBody);
+            then(result.isError()).isFalse();
+        }
+
+        @Test
+        void shouldHandleGetRequestWithObjectQueryParameterExplodedAsFormStyle() {
+            // Given
+            var fullOperation = new FullOperation("/users", PathItem.HttpMethod.GET, new Operation(), new OpenAPI());
+            var colorParameter = new LinkedHashMap<String, Object>();
+            colorParameter.put("R", 100);
+            colorParameter.put("G", 200);
+            colorParameter.put("B", 150);
+            var decomposedSchema = new DecomposedRequestData(
+                    new DecomposedRequestData.ParametersByType(
+                            Map.of(), Map.of("color", colorParameter), Map.of(), Map.of()),
+                    null);
+            var responseBody = "{\"users\":[]}";
+
+            wireMockServer.stubFor(get(urlPathEqualTo("/users"))
+                    .withQueryParam("R", equalTo("100"))
+                    .withQueryParam("G", equalTo("200"))
+                    .withQueryParam("B", equalTo("150"))
                     .withHeader("Accept", equalTo("application/json"))
                     .willReturn(aResponse().withStatus(200).withBody(responseBody)));
 


### PR DESCRIPTION
## Fix object-valued query, header, and cookie parameters

`ToolHandler` only special-cased `Iterable` values when serializing query, header, and cookie parameters. A `Map`-valued parameter (a JSON object) fell through to `value.toString()`, producing Java's `{key=value, ...}` syntax — breaking query parameters outright (Spring's `UriBuilder` misparsed it as a URI template variable) and producing invalid header/cookie values.

Fixes infobip/infobip-openapi-mcp#46.

Per the OpenAPI [style examples](https://github.com/oai/openapi-specification/blob/main/versions/3.1.0.md#style-examples) and [serialization guide](https://swagger.io/docs/specification/v3_0/serialization/), the framework only supports the default style/explode per location. Given `{"R":100,"G":200,"B":150}`:

| Location | Style | Explode | Result |
|---|---|---|---|
| Query | `form` | `true` | `R=100&G=200&B=150` |
| Header | `simple` | `false` | `R,100,G,200,B,150` |
| Cookie | `form` | `true` | `R=100; G=200; B=150` |

The spec leaves object serialization undefined for `form`-style cookies with `explode: true` — we mirror query handling there for consistency and document it as a pragmatic choice, not a spec-mandated one.

**Changes:** `addQueryParameter`/`addHeaderParameter`/`addCookieParameter` now handle `Map` values before falling back to `toString()`, with regression tests for all three locations, updated Javadoc/README (using the spec's own `color` example), and a CHANGELOG entry.
